### PR TITLE
Add Loom RPC client to interact with DPOS contract 

### DIFF
--- a/packages/rpc/src/loom/LoomRPC.spec.ts
+++ b/packages/rpc/src/loom/LoomRPC.spec.ts
@@ -1,0 +1,44 @@
+import { LoomRPC } from './LoomRPC';
+import { getEnv } from '../utils';
+
+describe('LoomRPC', () => {
+    let rpc: LoomRPC;
+    let address: string;
+    let delegationAddress: string;
+    let delegator: string;
+
+    beforeAll(() => {
+        require('dotenv').config({ path: __dirname + '/./.env' });
+        rpc = new LoomRPC(getEnv('Loom_RPC_URL'));
+        address = 'Loom1lcgtmf3gkdq4cuelly6554znqqhsl6eqy4r3f5';
+        delegationAddress = 'Loom1vjrx0lks65yefnsz4xk92vugda2z25esym5ypp';
+        delegator = 'Loom1xcn6f52mall95cw798qgftsvxvqrrdj535t8pm';
+    });
+
+    it('should get account', async () => {
+        let account = await rpc.getAccount(address);
+        expect(account.address).toBe(address);
+    }, 100000);
+
+    it('should list delegations', async () => {
+        let delegations = await rpc.listDelegations(delegationAddress);
+        expect(delegations.length).toBeTruthy();
+    });
+
+    it('should list unbonding delegations', async () => {
+        let delegations = await rpc.listUnbondDelegations(delegator);
+        expect(delegations.length).toBeTruthy();
+    });
+
+    it('should list get rewards', async () => {
+        let reward = await rpc.getRewards(delegator);
+        expect(reward.toNumber()).toBeGreaterThan(0.0);
+    });
+
+    it('should broadcast transaction', async () => {
+        let data =
+            '{"tx":{"memo":"","signatures":[{"pub_key":{"type":"tendermint\\/PubKeySecp256k1","value":"ApGCXwby9foj0IAqOYvmjI+Sd2qdGVdyI1h+CiIFY8xF"},"signature":"5je8nZG5k3Qel1LeJ8f0QAZjwaeRK5Uw\\/DOaPHE64MBCAqYYZCO5l\\/mkxLSzQyxJABk14m+gzCNpSNHiWQm84w=="}],"msg":[{"type":"Loom-sdk\\/MsgSend","value":{"amount":[{"amount":"2241155","denom":"uatom"}],"from_address":"Loom135qla4294zxarqhhgxsx0sw56yssa3z0f78pm0","to_address":"Loom1suasadhn8wmueg93u6js8ala89azqwg6fswuln"}}],"type":"Loom-sdk\\/MsgSend","fee":{"amount":[{"amount":"1000","denom":"uatom"}],"gas":"200000"}},"mode":"async"}';
+        let result = await rpc.broadcastTransaction(data);
+        expect(result.txhash).toBeDefined();
+    });
+});

--- a/packages/rpc/src/loom/LoomRPC.test.ts
+++ b/packages/rpc/src/loom/LoomRPC.test.ts
@@ -1,0 +1,59 @@
+import axios from 'axios';
+import { getEnv } from '../utils';
+import { LoomRPC } from './LoomRPC';
+
+describe('LoomRPC', () => {
+    let rpc: LoomRPC;
+    const address = 'Loom1lcgtmf3gkdq4cuelly6554znqqhsl6eqy4r3f5';
+    const delegationAddress = 'Loom1vjrx0lks65yefnsz4xk92vugda2z25esym5ypp';
+    const delegator = 'Loom1xcn6f52mall95cw798qgftsvxvqrrdj535t8pm';
+
+    beforeEach(function() {
+        require('dotenv').config({ path: __dirname + '/./.env' });
+        rpc = new LoomRPC(getEnv('Loom_RPC_URL'));
+    });
+
+    it('should get account', async () => {
+        spyOn(axios, 'get').and.returnValue({ data: '' });
+        spyOn(axios, 'post').and.returnValue({ data: '' });
+
+        const addToBeCalled = `${getEnv('Loom_RPC_URL')}/auth/accounts/${address}`;
+        await rpc.getAccount(address);
+        expect(axios.get).toHaveBeenCalledWith(addToBeCalled);
+    });
+
+    it('should list delegations', async () => {
+        spyOn(axios, 'get').and.returnValue({ data: '' });
+        spyOn(axios, 'post').and.returnValue({ data: '' });
+
+        await rpc.listDelegations(delegationAddress);
+        const toBeCalled = `${getEnv('Loom_RPC_URL')}/staking/delegators/${delegationAddress}/delegations`;
+        expect(axios.get).toHaveBeenCalledWith(toBeCalled);
+    });
+
+    it('should list unbonding delegations', async () => {
+        spyOn(axios, 'get').and.returnValue({ data: '' });
+        spyOn(axios, 'post').and.returnValue({ data: '' });
+
+        await rpc.listUnbondDelegations(delegator);
+        const toBeCalled = `${getEnv('Loom_RPC_URL')}/staking/delegators/${delegator}/unbonding_delegations`;
+        expect(axios.get).toHaveBeenCalledWith(toBeCalled);
+    });
+
+    it('should list get rewards', async () => {
+        spyOn(axios, 'get').and.returnValue({ data: [] });
+        spyOn(axios, 'post').and.returnValue({ data: '' });
+        await rpc.getRewards(delegator);
+        const toBeCalled = `${getEnv('Loom_RPC_URL')}/distribution/delegators/${delegator}/rewards`;
+        expect(axios.get).toHaveBeenCalledWith(toBeCalled);
+    });
+
+    it('should broadcast transaction', async () => {
+        spyOn(axios, 'get').and.returnValue({ data: '' });
+        spyOn(axios, 'post').and.returnValue({ data: '' });
+        const data =
+            '{"tx":{"memo":"","signatures":[{"pub_key":{"type":"tendermint\\/PubKeySecp256k1","value":"ApGCXwby9foj0IAqOYvmjI+Sd2qdGVdyI1h+CiIFY8xF"},"signature":"5je8nZG5k3Qel1LeJ8f0QAZjwaeRK5Uw\\/DOaPHE64MBCAqYYZCO5l\\/mkxLSzQyxJABk14m+gzCNpSNHiWQm84w=="}],"msg":[{"type":"Loom-sdk\\/MsgSend","value":{"amount":[{"amount":"2241155","denom":"uatom"}],"from_address":"Loom135qla4294zxarqhhgxsx0sw56yssa3z0f78pm0","to_address":"Loom1suasadhn8wmueg93u6js8ala89azqwg6fswuln"}}],"type":"Loom-sdk\\/MsgSend","fee":{"amount":[{"amount":"1000","denom":"uatom"}],"gas":"200000"}},"mode":"async"}';
+        await rpc.broadcastTransaction(data);
+        expect(axios.post).toHaveBeenCalled();
+    });
+});

--- a/packages/rpc/src/loom/LoomRPC.ts
+++ b/packages/rpc/src/loom/LoomRPC.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import { plainToClass } from 'class-transformer';
+import { LoomDelegation, LoomAccount, LoomBroadcastResult } from './models';
+import { Query } from './Query';
+import { LoomAccountResult } from './models/LoomAccount';
+import { LoomUnbond } from './models/LoomUnbond';
+import { LoomReward } from './models/LoomReward';
+import BigNumber from 'bignumber.js';
+import { Utils } from './utils';
+
+export class LoomRPC {
+    rpcUrl: string;
+
+    constructor(rpcUrl: string) {
+        this.rpcUrl = rpcUrl;
+    }
+
+    private query(): Query {
+        return new Query(this.rpcUrl);
+    }
+
+    async listDelegations(address: string): Promise<LoomDelegation[]> {
+        let response = await axios.get(this.query().listDelegations(address));
+        return plainToClass<LoomDelegation, any[]>(LoomDelegation, response.data);
+    }
+
+    async listUnbondDelegations(address: string): Promise<LoomUnbond[]> {
+        let response = await axios.get(this.query().listUnbondDelegations(address));
+        return plainToClass<LoomUnbond, any[]>(LoomUnbond, response.data);
+    }
+
+    async getAccount(address: string): Promise<LoomAccount> {
+        let response = await axios.get(this.query().getAccount(address));
+        return plainToClass(LoomAccountResult, response.data).value;
+    }
+
+    async getRewards(address: string): Promise<BigNumber> {
+        let response = await axios.get(this.query().getRewards(address));
+        return Utils.toAtom(
+            plainToClass<LoomReward, any[]>(LoomReward, response.data).reduce(
+                (acc, reward) => acc.plus(reward.amount),
+                new BigNumber(0),
+            ),
+        );
+    }
+
+    async broadcastTransaction(data: string): Promise<LoomBroadcastResult> {
+        const url = this.query().broadcastTransaction();
+        const options = {
+            validateStatus: (status: number) => {
+                return status >= 200 && status < 500;
+            },
+        };
+        const response = await axios.post(url, data, options);
+        return plainToClass(LoomBroadcastResult, response.data);
+    }
+}

--- a/packages/rpc/src/loom/Query.ts
+++ b/packages/rpc/src/loom/Query.ts
@@ -1,0 +1,17 @@
+export class Query {
+    rpcUrl: string;
+
+    constructor(rpcUrl: string) {
+        this.rpcUrl = rpcUrl;
+    }
+
+    listDelegations = (address: string) => this.uri(`query/listdelegations?address="${address}"`);
+    listUnbondDelegations = (address: string) => this.uri(`staking/delegators/${address}/unbonding_delegations`); // TODO
+    getRewards = (address: string) => this.uri(`query/rewards?address="${address}"`);
+    getAccount = (address: string) => this.uri(`query/getaccountinfo?address="${address}"`);
+    broadcastTransaction = () => this.uri('rpc');
+
+    private uri(path: string): string {
+        return `${this.rpcUrl}/${path}`;
+    }
+}

--- a/packages/rpc/src/loom/models/LoomAccount.ts
+++ b/packages/rpc/src/loom/models/LoomAccount.ts
@@ -1,0 +1,34 @@
+import 'reflect-metadata';
+import { Expose, Transform, Type } from 'class-transformer';
+import BigNumber from 'bignumber.js';
+
+class Coin {
+    denom: string;
+    @Transform(value => new BigNumber(value), { toClassOnly: true })
+    amount: BigNumber;
+}
+
+class PublicKey {
+    value: string;
+    type: string;
+}
+
+export class LoomAccount {
+    address: string;
+    @Type(() => PublicKey)
+    @Expose({ name: 'public_key' })
+    publicKey: PublicKey;
+    @Type(() => Coin)
+    coins: Coin[];
+    @Transform(value => new BigNumber(value), { toClassOnly: true })
+    @Expose({ name: 'account_number' })
+    accountNumber: BigNumber;
+    @Transform(value => Number(value), { toClassOnly: true })
+    sequence: number;
+}
+
+export class LoomAccountResult {
+    type: string;
+    @Type(() => LoomAccount)
+    value: LoomAccount;
+}

--- a/packages/rpc/src/loom/models/LoomBroadcastResult.ts
+++ b/packages/rpc/src/loom/models/LoomBroadcastResult.ts
@@ -1,0 +1,9 @@
+export class LoomBroadcastResult {
+    txhash?: string;
+    height?: number;
+    error?: string;
+
+    get isError(): boolean {
+        return this.error !== undefined;
+    }
+}

--- a/packages/rpc/src/loom/models/LoomDelegation.ts
+++ b/packages/rpc/src/loom/models/LoomDelegation.ts
@@ -1,0 +1,12 @@
+import 'reflect-metadata';
+import { Transform, Expose } from 'class-transformer';
+import BigNumber from 'bignumber.js';
+
+export class LoomDelegation {
+    @Expose({ name: 'delegator_address' })
+    delegatorAddress: string;
+    @Expose({ name: 'validator_address' })
+    validatorAddress: string;
+    @Transform(value => new BigNumber(value), { toClassOnly: true })
+    shares: BigNumber;
+}

--- a/packages/rpc/src/loom/models/LoomReward.ts
+++ b/packages/rpc/src/loom/models/LoomReward.ts
@@ -1,0 +1,9 @@
+import { Transform } from 'class-transformer';
+import BigNumber from 'bignumber.js';
+
+export class LoomReward {
+    denom: string;
+
+    @Transform(value => new BigNumber(value), { toClassOnly: true })
+    amount: BigNumber;
+}

--- a/packages/rpc/src/loom/models/LoomUnbond.ts
+++ b/packages/rpc/src/loom/models/LoomUnbond.ts
@@ -1,0 +1,35 @@
+import { Expose, Transform, Type } from 'class-transformer';
+import BigNumber from 'bignumber.js';
+import { Utils } from '../utils';
+
+class LoomUnbondEntry {
+    @Expose({name: 'creation_height'})
+    creationHeight: string;
+
+    @Type(() => Date)
+    @Expose({name: 'completion_time'})
+    completionTime: Date;
+
+    @Transform(value => new BigNumber(value), { toClassOnly: true })
+    @Expose({name: 'initial_balance'})
+    initialBalance: BigNumber;
+
+    @Transform(value => new BigNumber(value), { toClassOnly: true })
+    balance: BigNumber
+}
+
+export class LoomUnbond {
+    delegator_address: string;
+    validator_address: string;
+
+    @Type(() => LoomUnbondEntry)
+    entries: LoomUnbondEntry[];
+
+    getPending(): LoomUnbondEntry[] {
+        return this.entries.filter(entry => entry.completionTime.getDate() > Date.now())
+    }
+
+    getPendingBalance(): BigNumber {
+        return Utils.toAtom(this.getPending().reduce((acc, entry) => acc.plus(entry.balance), new BigNumber(0)))
+    }
+}

--- a/packages/rpc/src/loom/models/index.ts
+++ b/packages/rpc/src/loom/models/index.ts
@@ -1,0 +1,3 @@
+export { LoomAccount } from './LoomAccount';
+export { LoomDelegation } from './LoomDelegation';
+export { LoomBroadcastResult } from './LoomBroadcastResult';

--- a/packages/rpc/src/loom/utils.test.ts
+++ b/packages/rpc/src/loom/utils.test.ts
@@ -1,0 +1,9 @@
+import { Utils } from './utils';
+import BigNumber from 'bignumber.js';
+
+describe('CosmosUtils', () => {
+    it('should convert MicroAtom to Atom', () => {
+        const micro = new BigNumber(1000000000);
+        expect(Utils.toAtom(micro)).toEqual(micro.dividedBy(1000000));
+    });
+});

--- a/packages/rpc/src/loom/utils.ts
+++ b/packages/rpc/src/loom/utils.ts
@@ -1,0 +1,8 @@
+import BigNumber from 'bignumber.js';
+
+export class Utils {
+    static toAtom(microatom: BigNumber): BigNumber {
+        const denominator = new BigNumber(1000000);
+        return microatom.dividedBy(denominator);
+    }
+}


### PR DESCRIPTION
This PR will add these endpoints.

- listDelegations `/query/listdelegations?address=_`
- listUnbondDelegations `TODO`
- getRewards `query/rewards?address=_`
- getAccount  `query/getaccountinfo?address=_`
- broadcastTransaction `rpc/` POST with method `broadcast_tx_sync`

ref : https://github.com/loomnetwork/loomchain/issues/1458
https://github.com/loomnetwork/loomchain/issues/1460